### PR TITLE
Parse cache store in command as arg instead of flag

### DIFF
--- a/commands/cache_clear.ts
+++ b/commands/cache_clear.ts
@@ -7,7 +7,7 @@
  * file that was distributed with this source code.
  */
 
-import { BaseCommand, flags } from '@adonisjs/core/ace'
+import { args, BaseCommand } from '@adonisjs/core/ace'
 
 import { CacheService } from '../src/types.js'
 import { CommandOptions } from '@adonisjs/core/types/ace'
@@ -23,7 +23,7 @@ export default class CacheClear extends BaseCommand {
    * Choose a custom cache store to clear. Otherwise, we use the
    * default one
    */
-  @flags.string({ description: 'Define a custom cache store to clear', alias: 's' })
+  @args.string({ description: 'Define a custom cache store to clear', required: false })
   declare store: string
 
   /**
@@ -58,7 +58,7 @@ export default class CacheClear extends BaseCommand {
     this.store = this.store || cache.defaultStoreName
 
     /**
-     * Exit if cache store doesn't exists
+     * Exit if cache store doesn't exist
      */
     if (!this.#cacheExists(cache, this.store)) {
       this.logger.error(


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Currently the `cache:clear` command accepts a flag to select a specific store to clear while the docs mention an optional command argument. This PR changes the command to accept an Ace optional arg instead of a flag.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
