### PR TITLE
Allow cache:clear command to clear a specific namespace

### DIFF
--- a/commands/cache_clear.ts
+++ b/commands/cache_clear.ts
@@ -7,7 +7,7 @@
  * file that was distributed with this source code.
  */
 
-import { args, BaseCommand } from '@adonisjs/core/ace'
+import { args, BaseCommand, flags } from '@adonisjs/core/ace'
 
 import { CacheService } from '../src/types.js'
 import { CommandOptions } from '@adonisjs/core/types/ace'
@@ -25,6 +25,12 @@ export default class CacheClear extends BaseCommand {
    */
   @args.string({ description: 'Define a custom cache store to clear', required: false })
   declare store: string
+
+  /**
+   * Optionally select a namespace to clear. Defaults to the whole cache.
+   */
+  @flags.string({ description: 'Select a cache namespace to clear', alias: 'n' })
+  declare namespace: string
 
   /**
    * Prompts to take consent when clearing the cache in production
@@ -79,7 +85,15 @@ export default class CacheClear extends BaseCommand {
     /**
      * Finally clear the cache
      */
-    await cache.use(this.store).clear()
-    this.logger.success(`Cleared "${this.store}" cache successfully`)
+    const cacheHandler = cache.use(this.store)
+    if (this.namespace) {
+      await cacheHandler.namespace(this.namespace).clear()
+      this.logger.success(
+        `Cleared namespace "${this.namespace}" for "${this.store}" cache successfully`
+      )
+    } else {
+      await cacheHandler.clear()
+      this.logger.success(`Cleared "${this.store}" cache successfully`)
+    }
   }
 }

--- a/tests/commands/cache_clear.spec.ts
+++ b/tests/commands/cache_clear.spec.ts
@@ -136,4 +136,30 @@ test.group('CacheClear', () => {
     )
     assert.equal(command.exitCode, 1)
   })
+
+  test('Clear a specific namespace in the default cache', async ({ fs, assert }) => {
+    const ace = await new AceFactory().make(fs.baseUrl, { importer: () => {} })
+    await ace.app.init()
+
+    const cache = getCacheService()
+    ace.app.container.singleton('cache.manager', () => cache)
+    ace.ui.switchMode('raw')
+
+    await cache.set({ key: 'foo', value: 'bar' })
+    assert.equal(await cache.get({ key: 'foo' }), 'bar')
+
+    await cache.namespace('users').set({ key: 'foo', value: 'bar' })
+    assert.equal(await cache.namespace('users').get({ key: 'foo' }), 'bar')
+
+    const command = await ace.create(CacheClear, [])
+    command.namespace = 'users'
+    await command.run()
+
+    assert.equal(await cache.get({ key: 'foo' }), 'bar')
+    assert.isUndefined(await cache.namespace('users').get({ key: 'foo' }))
+
+    command.assertLog(
+      `[ green(success) ] Cleared namespace "users" for "${cache.defaultStoreName}" cache successfully`
+    )
+  })
 })


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [X] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Bentocache supports [namespaces](https://bentocache.dev/docs/namespaces) as a way to organise cached data. It is often useful to manually clear the data in a specific namespace.

This PR adds a flag (`--namespace` or `-n`) to the `cache:clear` command to support clearing a specific namespace.

Note: while Bentocache namespaces allow for recursive nesting this command operates only on the first level from the cache root for sake of simplicity (it is likely to be also the most common need).

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
