### PR TITLE
fix: REPL breaks after installing cache

### DIFF
--- a/providers/cache_provider.ts
+++ b/providers/cache_provider.ts
@@ -9,7 +9,7 @@
 
 import type { ApplicationService } from '@adonisjs/core/types'
 
-import { defineConfig } from '../index.js'
+import { type defineConfig } from '../index.js'
 import type { CacheEvents } from 'bentocache/types'
 import type { CacheService } from '../src/types.js'
 import { defineReplBindings } from '../src/bindings/repl.js'
@@ -49,7 +49,7 @@ export default class CacheProvider {
   /**
    * Register the cache manager to the container
    */
-  async #registerCacheManager() {
+  #registerCacheManager() {
     const cacheConfig = this.app.config.get<ReturnType<typeof defineConfig>>('cache')
 
     this.app.container.singleton('cache.manager', async () => {
@@ -97,15 +97,15 @@ export default class CacheProvider {
   /**
    * Register bindings
    */
-  async register() {
-    await this.#registerCacheManager()
-    await this.#registerEdgeBindings()
+  register() {
+    this.#registerCacheManager()
   }
 
   /**
    * Boot provider
    */
   async boot() {
+    await this.#registerEdgeBindings()
     await this.#registerReplBindings()
   }
 

--- a/providers/cache_provider.ts
+++ b/providers/cache_provider.ts
@@ -99,8 +99,14 @@ export default class CacheProvider {
    */
   async register() {
     await this.#registerCacheManager()
-    await this.#registerReplBindings()
     await this.#registerEdgeBindings()
+  }
+
+  /**
+   * Boot provider
+   */
+  async boot() {
+    await this.#registerReplBindings()
   }
 
   /**

--- a/src/bindings/edge.ts
+++ b/src/bindings/edge.ts
@@ -8,7 +8,7 @@
  */
 
 import debug from '../debug.js'
-import { CacheService } from '../types.js'
+import { type CacheService } from '../types.js'
 
 export async function registerViewBindings(manager: CacheService) {
   const edge = await import('edge.js')

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,7 +35,6 @@ export interface CacheStores {}
 /**
  * The cache service interface registered with the container
  */
-export interface CacheService
-  extends BentoCache<
-    CacheStores extends Record<string, ReturnType<typeof bentostore>> ? CacheStores : never
-  > {}
+export interface CacheService extends BentoCache<
+  CacheStores extends Record<string, ReturnType<typeof bentostore>> ? CacheStores : never
+> {}

--- a/tests/provider.spec.ts
+++ b/tests/provider.spec.ts
@@ -53,4 +53,16 @@ test.group('Provider', () => {
     assert.property(replMethods, 'loadCache')
     assert.isFunction(replMethods.loadCache.handler)
   })
+
+  test('existing repl bindings', async ({ assert }) => {
+    const app = await setupApp('repl')
+
+    const repl = await app.container.make('repl')
+    const replMethods = repl.getMethods()
+
+    assert.property(replMethods, 'importDefault')
+    assert.property(replMethods, 'importAll')
+    assert.property(replMethods, 'loadApp')
+    assert.property(replMethods, 'loadConfig')
+  })
 })


### PR DESCRIPTION
### 🔗 Linked issue

#13

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Registering REPL bindings in the register() hook was interfering with REPL initialization, causing standard bindings like loadApp to disappear. Moving to boot() ensures REPL is fully initialized before we add our bindings.

Resolves #13

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
- [x] Pass all tests
